### PR TITLE
Add apache for ci tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LI
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y libxml2-utils mysql-client postgresql-client sqlite git-core unzip npm nodejs-legacy wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip npm nodejs-legacy wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/rootfs/etc/apache2/conf-enabled/security.conf
+++ b/rootfs/etc/apache2/conf-enabled/security.conf
@@ -1,0 +1,3 @@
+ServerTokens Prod
+ServerSignature Off
+TraceEnable Off

--- a/rootfs/etc/apache2/conf-enabled/servername.conf
+++ b/rootfs/etc/apache2/conf-enabled/servername.conf
@@ -1,0 +1,1 @@
+ServerName localhost

--- a/rootfs/etc/apache2/sites-enabled/000-default.conf
+++ b/rootfs/etc/apache2/sites-enabled/000-default.conf
@@ -1,0 +1,29 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/owncloud
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog /dev/stdout
+	CustomLog /dev/stdout combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>

--- a/rootfs/etc/apache2/templates/base.conf
+++ b/rootfs/etc/apache2/templates/base.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot ${APACHE_WEBROOT}
+
+	ErrorLog /dev/stdout
+	CustomLog /dev/stdout combined
+
+	<Directory ${APACHE_WEBROOT}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>

--- a/rootfs/usr/local/bin/apachectl
+++ b/rootfs/usr/local/bin/apachectl
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+declare -x APACHE_TEMPLATE_PATH
+[[ -z "${APACHE_TEMPLATE_PATH}" ]] && APACHE_TEMPLATE_PATH="/etc/apache2/templates"
+
+declare -x APACHE_CONFIG_TEMPLATE
+[[ -z "${APACHE_CONFIG_TEMPLATE}" ]] && APACHE_CONFIG_TEMPLATE="${APACHE_TEMPLATE_PATH}/base.conf"
+
+declare -x APACHE_WEBROOT
+[[ -z "${APACHE_WEBROOT}" ]] && APACHE_WEBROOT="/var/www/owncloud"
+
+echo "Writing apache config..."
+envsubst \
+'${APACHE_WEBROOT}' \
+  < ${APACHE_CONFIG_TEMPLATE} > /etc/apache2/sites-enabled/000-default.conf
+
+echo "Starting apache... "
+exec /usr/sbin/apachectl "$@"


### PR DESCRIPTION
Superseeds #12 (could not push to remote branch from @individual-it :'( )

Contains a wrapper called `apachectl-ci` which accepts environment vars for setting the document root: `APACHE_WEBROOT` 

It also already includes `APACHE_TEMPLATE_PATH` and `APACHE_CONFIG_TEMPLATE` to override the very basic template file.

Use cases:
- using apache as simple webdav endpoint server for `files_external` tests
- having more specific apache configs for certain applications 

Needs backporting to (be careful with package names since some other php versions use ppa repositories)
- [ ] 5.6
- [ ] 7.0 
- [ ] 7.1
- [ ] 7.2 

## Notes:

- [ ] also include a configuration to enable/generate a ssl certificate for testing scenarios with ssl enabled (i.e. federated sharing -> we could copy/import the certificate into the keychain? Or we could provide a CA that we trust from which we can generate trusted certificates within this container) 