### PR TITLE
add xdebug and wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,10 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip nodejs yarn wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-ast && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip nodejs yarn wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-ast php-xdebug && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
+  phpdismod xdebug && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,4 @@ RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/includ
 
 COPY rootfs /
 WORKDIR /var/www/owncloud
+ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/rootfs/etc/entrypoint.d/00-xdebug-enable.sh
+++ b/rootfs/etc/entrypoint.d/00-xdebug-enable.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+declare -x XDEBUG_ENABLED
+[[ -z "${XDEBUG_ENABLED}" ]] && XDEBUG_ENABLED="false"
+
+declare -x XDEBUG_REMOTE_ENABLE
+[[ -z "${XDEBUG_REMOTE_ENABLE}" ]] && XDEBUG_REMOTE_ENABLE="1"
+
+declare -x XDEBUG_REMOTE_AUTOSTART
+[[ -z "${XDEBUG_REMOTE_AUTOSTART}" ]] && XDEBUG_REMOTE_AUTOSTART="1"
+
+declare -x XDEBUG_REMOTE_PORT
+[[ -z "${XDEBUG_REMOTE_PORT}" ]] && XDEBUG_REMOTE_PORT="9000"
+
+declare -x XDEBUG_REMOTE_HOST
+[[ -z "${XDEBUG_REMOTE_HOST}" ]] && XDEBUG_REMOTE_HOST="localhost"
+
+declare -x XDEBUG_REMOTE_CONNECT_BACK
+[[ -z "${XDEBUG_REMOTE_CONNECT_BACK}" ]] && XDEBUG_REMOTE_CONNECT_BACK="0"
+
+declare -x XDEBUG_IDEKEY
+[[ -z "${XDEBUG_IDEKEY}" ]] && XDEBUG_IDEKEY="PHPSTORM"
+
+if [[ "${XDEBUG_ENABLED}" == "true" || "${XDEBUG_ENABLED}" == "1" ]]; then
+
+  echo "configuring xdebug"
+  php_version=$(phpquery -V)
+
+  envsubst \
+    '${XDEBUG_REMOTE_ENABLE} ${XDEBUG_REMOTE_AUTOSTART} ${XDEBUG_IDEKEY} ${XDEBUG_REMOTE_PORT} ${XDEBUG_REMOTE_HOST} ${XDEBUG_REMOTE_CONNECT_BACK}' \
+      < /etc/templates/xdebug.tmpl >| "/etc/php/${php_version}/mods-available/00-xdebug.ini"
+
+  for SAPI in $( echo "cli,apache2,fpm" | tr "," " ")
+    do
+      if [[ ! -e "/etc/php/${php_version}/${SAPI}/conf.d/00-xdebug.ini" ]]; then
+        ln -s /etc/php/${php_version}/mods-available/00-xdebug.ini /etc/php/${php_version}/${SAPI}/conf.d/00-xdebug.ini
+      fi
+    done
+fi
+
+true

--- a/rootfs/etc/templates/xdebug.tmpl
+++ b/rootfs/etc/templates/xdebug.tmpl
@@ -1,0 +1,6 @@
+xdebug.remote_enable=${XDEBUG_REMOTE_ENABLE}
+xdebug.remote_autostart=${XDEBUG_REMOTE_AUTOSTART}
+xdebug.idekey=${XDEBUG_IDEKEY}
+xdebug.remote_port=${XDEBUG_REMOTE_PORT}
+xdebug.remote_host=${XDEBUG_REMOTE_HOST}
+xdebug.remote_connect_back=${XDEBUG_REMOTE_CONNECT_BACK}

--- a/rootfs/usr/local/bin/entrypoint
+++ b/rootfs/usr/local/bin/entrypoint
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eo pipefail
+[[ "${DEBUG}" == "true" ]] && set -x
+
+for FILE in $(find /etc/entrypoint.d -iname \*.sh | sort)
+do
+  source ${FILE}
+done
+
+exec $@


### PR DESCRIPTION
closes #60 

This PR adds `xdebug` extension into the container - but it is disabled by default.

With the following environment variables it can be enabled / or behavior controlled

```
XDEBUG_ENABLED
XDEBUG_REMOTE_ENABLE
XDEBUG_REMOTE_AUTOSTART
XDEBUG_REMOTE_PORT
XDEBUG_REMOTE_HOST
XDEBUG_REMOTE_CONNECT_BACK
XDEBUG_IDEKEY
```

@tboerger 
I added entrypoing as helper - so it can also be enabled in `.drone.yml` when developers would like to run `drone exec` but use debugging

Other use case would be "composable infrastructure"