### PR TITLE
allow to start apache with HTTPS

### DIFF
--- a/rootfs/etc/apache2/templates/ssl
+++ b/rootfs/etc/apache2/templates/ssl
@@ -1,0 +1,19 @@
+<IfModule mod_ssl.c>
+	<VirtualHost *:443>
+		ServerAdmin webmaster@localhost
+		DocumentRoot ${APACHE_WEBROOT} 
+
+		ErrorLog /dev/stdout
+		CustomLog /dev/stdout combined
+
+		<Directory ${APACHE_WEBROOT}>
+			Options Indexes FollowSymLinks MultiViews
+			AllowOverride All
+			Require all granted
+		</Directory>
+
+		SSLEngine on
+		SSLCertificateFile	${APACHE_SSL_CERT}
+		SSLCertificateKeyFile	${APACHE_SSL_KEY} 
+	</VirtualHost>
+</IfModule>

--- a/rootfs/usr/local/bin/apachectl
+++ b/rootfs/usr/local/bin/apachectl
@@ -10,6 +10,15 @@ declare -x APACHE_CONFIG_TEMPLATE
 declare -x APACHE_WEBROOT
 [[ -z "${APACHE_WEBROOT}" ]] && APACHE_WEBROOT="/var/www/owncloud"
 
+declare -x APACHE_SSL_CERT_CN
+[[ -z "${APACHE_SSL_CERT_CN}" ]] && APACHE_SSL_CERT_CN="server"
+
+declare -x APACHE_SSL_CERT
+[[ -z "${APACHE_SSL_CERT}" ]] && APACHE_SSL_CERT="/etc/apache2/ssl/${APACHE_SSL_CERT_CN}.crt"
+
+declare -x APACHE_SSL_KEY
+[[ -z "${APACHE_SSL_KEY}" ]] && APACHE_SSL_KEY="/etc/apache2/ssl/${APACHE_SSL_CERT_CN}.key"
+
 declare -x APACHE_WEBDAV_AUTHFILE
 [[ -z "${APACHE_WEBDAV_AUTHFILE}" ]] && APACHE_WEBDAV_AUTHFILE="/etc/apache2/webdav.auth"
 
@@ -31,6 +40,13 @@ if [[ ${APACHE_CONFIG_TEMPLATE} == "webdav" ]]; then
 
     echo "Fixing directory access"
     chown www-data:www-data "${APACHE_WEBROOT}"
+fi
+
+if [[ ! -f ${APACHE_SSL_KEY} || ! -f ${APACHE_SSL_CERT} ]]
+then
+    echo "Generating SSL certificates for ${APACHE_SSL_CERT_CN} ..."
+    SSL_SUBJ="/C=DE/ST=Bavaria/L=Nuremberg/O=ownCloud GmbH/CN=${APACHE_SSL_CERT_CN}"
+    openssl req -x509 -subj "${SSL_SUBJ}" -sha256 -nodes -days 1825 -newkey rsa:4096 -keyout ${APACHE_SSL_KEY} -out ${APACHE_SSL_CERT}
 fi
 
 echo "Writing apache config..."


### PR DESCRIPTION
messed up #73 starting fresh
this PR makes it possible to start the apache server with HTTPS by using:
`APACHE_CONFIG_TEMPLATE=ssl`

also `APACHE_SSL_CERT` and `APACHE_SSL_KEY` can be used to configure the SSL certificate and key that should be used.

if the key and certificate file do not exist, they will be created

see: owncloud/core#32550

@patrickjahns  please review