### PR TITLE
install rsync in container

### DIFF
--- a/v5.6/Dockerfile.amd64
+++ b/v5.6/Dockerfile.amd64
@@ -22,7 +22,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-mark hold php-apcu-bc && \
-  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu && \
+  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v5.6/Dockerfile.arm32v7
+++ b/v5.6/Dockerfile.arm32v7
@@ -19,7 +19,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-mark hold php-apcu-bc && \
-  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu && \
+  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v5.6/Dockerfile.arm64v8
+++ b/v5.6/Dockerfile.arm64v8
@@ -19,7 +19,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-mark hold php-apcu-bc && \
-  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu && \
+  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.arm32v7
+++ b/v7.0/Dockerfile.arm32v7
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.arm32v7
+++ b/v7.1/Dockerfile.arm32v7
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.arm32v7
+++ b/v7.2/Dockerfile.arm32v7
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm32v7
+++ b/v7.3/Dockerfile.arm32v7
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
the current version of the container does not have rsync installed. The reason might have been the change from ubuntu 16:04 to 18:04 in #101 see https://github.com/owncloud-ci/php/pull/101/files#diff-ebacd6eb223909eb1bf32a1089f94ea4R1
rsync is needed to install the test-runner in acceptance tests, see https://github.com/owncloud/user_ldap/blob/master/.drone.starlark#L1590