### PR TITLE
consistent Dockerfile copy overlay

### DIFF
--- a/v5.6/Dockerfile.arm32v7
+++ b/v5.6/Dockerfile.arm32v7
@@ -26,5 +26,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm32v7 /
 WORKDIR /var/www/owncloud

--- a/v5.6/Dockerfile.arm64v8
+++ b/v5.6/Dockerfile.arm64v8
@@ -26,5 +26,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm64v8 /
 WORKDIR /var/www/owncloud

--- a/v7.0/Dockerfile.arm32v7
+++ b/v7.0/Dockerfile.arm32v7
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm32v7 /
 WORKDIR /var/www/owncloud

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm64v8 /
 WORKDIR /var/www/owncloud

--- a/v7.1/Dockerfile.arm32v7
+++ b/v7.1/Dockerfile.arm32v7
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm32v7 /
 WORKDIR /var/www/owncloud

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm64v8 /
 WORKDIR /var/www/owncloud

--- a/v7.2/Dockerfile.arm32v7
+++ b/v7.2/Dockerfile.arm32v7
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm32v7 /
 WORKDIR /var/www/owncloud

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm64v8 /
 WORKDIR /var/www/owncloud

--- a/v7.3/Dockerfile.arm32v7
+++ b/v7.3/Dockerfile.arm32v7
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm32v7 /
 WORKDIR /var/www/owncloud

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -25,5 +25,5 @@ RUN apt-get update -y && \
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-COPY ./overlay ./overlay-amd64 /
+COPY ./overlay ./overlay-arm64v8 /
 WORKDIR /var/www/owncloud


### PR DESCRIPTION
These "copy overlay" in the various `Dockerfile` looked inconsistent.
They should mention the `overlay-*` for their architecture?