### PR TITLE
Add text to README with patch version date

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Build Status](https://cloud.drone.io/api/badges/owncloud-ci/php/status.svg)](https://cloud.drone.io/owncloud-ci/php)
 [![](https://images.microbadger.com/badges/image/owncloudci/php.svg)](https://microbadger.com/images/owncloudci/php "Get your own image badge on microbadger.com")
 
-TBD
+This repo provides docker images with the PHP versions listed below.
+The patch versions of each minor release are up-to-date with official PHP releases as at 19 Dec 2019.
 
 ## Versions
 


### PR DESCRIPTION
This should cause the docker images to be re-released and they should automagically end up with the new patch versions of PHP that were released yesterday, 18 Dec 2019:
https://www.php.net/ChangeLog-7.php
7.4.1
7.3.13
7.2.26
The following versions are out of official support, and so will remain at their latest patch releases:
7.1.33
7.0.33
5.6.40