### PR TITLE
Remove whitespace from .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -265,8 +265,6 @@ def sleep(config):
     ],
   }]
 
-
-
 def server(config):
   return [{
     'name': 'server',


### PR DESCRIPTION
I  tried restarting the last merge CI in order to update the docker images so that they have the latest patch releases of PHP 7.3 and 7.4, and the official release of PHP 8.0. But CI gives errors in the prepublish step:
https://cloud.drone.io/owncloud-ci/php/48/1/2
```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

So let's try this little PR and see what happens.