### PR TITLE
Use Ubuntu 20.04 for PHP 8.0

### DIFF
--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:18.04-amd64
+FROM owncloud/ubuntu:20.04-amd64
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI PHP" \

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:18.04-arm64v8
+FROM owncloud/ubuntu:20.04-arm64v8
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI PHP" \


### PR DESCRIPTION
Nothing "real" is using PHP 8.0 yet, so doing this will not break any configured CI. If we use Ubuntu 20.04 then we will get later versions of other non-PHP stuff that is also built-in to this docker image, `nodejs` for example. That will give us the option to use this `owncloudci/php:8.0` image for various up-to-date stuff when we want.

The immediate thing that I wanted to try is that this should give a newer `nodejs` version as a side-effect.