### PR TITLE
Specifically install npm in Ubuntu 20.04 PHP 8.0 image

### DIFF
--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
In https://drone.owncloud.com/owncloud/activity/1682/2/4 I got:
```
+ make test-js
Makefile:13: *** npm is not available on your system, please install npm.  Stop.
```

That's a bit sad :( - I guess that somehow `npm` came "for free" with `nodejs` version 8 when installing on Ubuntu 18.04, and that it has to be specifically mentioned when installing major version 10 on Ubuntu 20.04.