### PR TITLE
Revert "Use Ubuntu 20.04 as the base for PHP 7.4"

### DIFF
--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:20.04-amd64
+FROM owncloud/ubuntu:18.04-amd64
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI PHP" \
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM owncloud/ubuntu:20.04-arm64v8
+FROM owncloud/ubuntu:18.04-arm64v8
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud CI PHP" \
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
This reverts commit 632543508a3d59cf652adbc6f18d27ee77af598a.

There are unit tests failing in core with the Ubuntu 20.04 PHP 7.4 docker image. I need to investigate why, but for now we had better revert back and get CI  green again. Issue https://github.com/owncloud/core/issues/38348