### PR TITLE
Install explicit versions of PHP extensions

### DIFF
--- a/v5.6/Dockerfile.amd64
+++ b/v5.6/Dockerfile.amd64
@@ -22,7 +22,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-mark hold php-apcu-bc && \
-  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-gmp php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu rsync && \
+  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-gmp php5.6-imap php5.6-redis php5.6-memcached php5.6-imagick php5.6-smbclient php5.6-apcu rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v5.6/Dockerfile.arm64v8
+++ b/v5.6/Dockerfile.arm64v8
@@ -19,7 +19,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-mark hold php-apcu-bc && \
-  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-gmp php5.6-imap php-redis php-memcached php-imagick php-smbclient php-apcu rsync && \
+  apt-get install -y apache2 libapache2-mod-php5.6 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php5.6 php5.6-dev php5.6-xml php5.6-mbstring php5.6-curl php5.6-gd php5.6-zip php5.6-intl php5.6-sqlite3 php5.6-mysql php5.6-pgsql php5.6-soap php5.6-phpdbg php5.6-ldap php5.6-gmp php5.6-imap php5.6-redis php5.6-memcached php5.6-imagick php5.6-smbclient php5.6-apcu rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php-redis php-memcached php-imagick php-smbclient php-apcu php-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
After re-running the last Merge CI to recreate `owncloudci/php` docker images to get the latest PHP patch releases, we are getting errors in CI like: https://drone.owncloud.com/owncloud/core/29750/5/7
```
ERROR: The php-ast extension must be loaded in order for Phan to work. Either install and enable php-ast, or invoke Phan with the CLI option --allow-polyfill-parser (which is noticeably slower)
```

I get the same when doing `make test-php-phan` locally with PHP 7.4.18

I have to `sudo apt install php7.4-ast` t get rid of that error.

Then I have to also install other extensions using the explicit version number to get `phan` to pass:
```
sudo apt install php7.4-memcached
sudo apt install php7.4-redis
sudo apt install php7.4-imagick
```

It seems that nowadays we have to explicitly mention the PHP version number when installing the extensions.

TBH I have no idea why it worked before, but broke somewhere in the last 2 months.