### PR TITLE
Add apcu-bc backward-compatibility extension to PHP 7.*

### DIFF
--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-apcu-bc php7.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.0 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.0 php7.0-dev php7.0-xml php7.0-mbstring php7.0-curl php7.0-gd php7.0-zip php7.0-intl php7.0-sqlite3 php7.0-mysql php7.0-pgsql php7.0-soap php7.0-phpdbg php7.0-ldap php7.0-gmp php7.0-imap php7.0-redis php7.0-memcached php7.0-imagick php7.0-smbclient php7.0-apcu php7.0-apcu-bc php7.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-apcu-bc php7.1-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.1 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.1 php7.1-dev php7.1-xml php7.1-mbstring php7.1-curl php7.1-gd php7.1-zip php7.1-intl php7.1-sqlite3 php7.1-mysql php7.1-pgsql php7.1-soap php7.1-phpdbg php7.1-ldap php7.1-gmp php7.1-imap php7.1-redis php7.1-memcached php7.1-imagick php7.1-smbclient php7.1-apcu php7.1-apcu-bc php7.1-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-apcu-bc php7.2-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.2 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.2 php7.2-dev php7.2-xml php7.2-mbstring php7.2-curl php7.2-gd php7.2-zip php7.2-intl php7.2-sqlite3 php7.2-mysql php7.2-pgsql php7.2-soap php7.2-phpdbg php7.2-ldap php7.2-gmp php7.2-imap php7.2-redis php7.2-memcached php7.2-imagick php7.2-smbclient php7.2-apcu php7.2-apcu-bc php7.2-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/core/29752/6/7
`lib/private/Memcache/APCu.php:62 PhanUndeclaredClassMethod Call to method __construct from undeclared class \APCIterator (Did you mean to configure a stub with https://github.com/phan/phan/wiki/How-To-Use-Stubs#internal-stubs or to enable the extension providing the class. or class \APCUIterator)`

https://stackoverflow.com/questions/37394828/apciterator-class-not-found-for-php7

ownCloud still has some reference to `APCIterator` (the "modern" version is `APCUIterator`) - that old class is in the backward-compatibility extension for apcu.

I have no idea why this is now needed. I guess that until recently the backward-compatibility extension somehow got automagically selected for install, or?