### PR TITLE
Add APACHE_LOGGING_PATH path env variable for apache customlogs

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/latest/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/latest/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/latest/overlay/etc/apache2/templates/base
+++ b/latest/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/latest/overlay/etc/apache2/templates/ssl
+++ b/latest/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/latest/overlay/etc/apache2/templates/webdav
+++ b/latest/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v5.6/Dockerfile.amd64
+++ b/v5.6/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v5.6/Dockerfile.arm64v8
+++ b/v5.6/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v5.6/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v5.6/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v5.6/overlay/etc/apache2/templates/base
+++ b/v5.6/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v5.6/overlay/etc/apache2/templates/ssl
+++ b/v5.6/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v5.6/overlay/etc/apache2/templates/webdav
+++ b/v5.6/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.0/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.0/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.0/overlay/etc/apache2/templates/base
+++ b/v7.0/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.0/overlay/etc/apache2/templates/ssl
+++ b/v7.0/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.0/overlay/etc/apache2/templates/webdav
+++ b/v7.0/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.1/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.1/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.1/overlay/etc/apache2/templates/base
+++ b/v7.1/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.1/overlay/etc/apache2/templates/ssl
+++ b/v7.1/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.1/overlay/etc/apache2/templates/webdav
+++ b/v7.1/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.2/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.2/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.2/overlay/etc/apache2/templates/base
+++ b/v7.2/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.2/overlay/etc/apache2/templates/ssl
+++ b/v7.2/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.2/overlay/etc/apache2/templates/webdav
+++ b/v7.2/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.3/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.3/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.3/overlay/etc/apache2/templates/base
+++ b/v7.3/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.3/overlay/etc/apache2/templates/ssl
+++ b/v7.3/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.3/overlay/etc/apache2/templates/webdav
+++ b/v7.3/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.4-ubuntu20.04/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.4-ubuntu20.04/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.4-ubuntu20.04/overlay/etc/apache2/templates/base
+++ b/v7.4-ubuntu20.04/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.4-ubuntu20.04/overlay/etc/apache2/templates/ssl
+++ b/v7.4-ubuntu20.04/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.4-ubuntu20.04/overlay/etc/apache2/templates/webdav
+++ b/v7.4-ubuntu20.04/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v7.4/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v7.4/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v7.4/overlay/etc/apache2/templates/base
+++ b/v7.4/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v7.4/overlay/etc/apache2/templates/ssl
+++ b/v7.4/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v7.4/overlay/etc/apache2/templates/webdav
+++ b/v7.4/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -9,6 +9,7 @@ VOLUME ["/var/www/owncloud"]
 
 ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -6,6 +6,7 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.schema-version="1.0"
 
 VOLUME ["/var/www/owncloud"]
+ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \

--- a/v8.0/overlay/etc/apache2/sites-enabled/000-default.conf
+++ b/v8.0/overlay/etc/apache2/sites-enabled/000-default.conf
@@ -3,5 +3,5 @@
 	DocumentRoot /var/www/owncloud
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 </VirtualHost>

--- a/v8.0/overlay/etc/apache2/templates/base
+++ b/v8.0/overlay/etc/apache2/templates/base
@@ -3,7 +3,7 @@
 	DocumentRoot ${APACHE_WEBROOT}
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	<Directory ${APACHE_WEBROOT}>
 		Options Indexes FollowSymLinks MultiViews

--- a/v8.0/overlay/etc/apache2/templates/ssl
+++ b/v8.0/overlay/etc/apache2/templates/ssl
@@ -4,7 +4,7 @@
 		DocumentRoot ${APACHE_WEBROOT} 
 
 		ErrorLog /dev/stdout
-		CustomLog /dev/stdout combined
+		CustomLog ${APACHE_LOGGING_PATH} combined
 
 		<Directory ${APACHE_WEBROOT}>
 			Options Indexes FollowSymLinks MultiViews

--- a/v8.0/overlay/etc/apache2/templates/webdav
+++ b/v8.0/overlay/etc/apache2/templates/webdav
@@ -2,7 +2,7 @@
 	DavLockDB "/tmp/lockdb"
 
 	ErrorLog /dev/stdout
-	CustomLog /dev/stdout combined
+	CustomLog ${APACHE_LOGGING_PATH} combined
 
 	ServerAdmin webmaster@localhost
 	DocumentRoot ${APACHE_WEBROOT}


### PR DESCRIPTION
Fixes https://github.com/owncloud-ci/php/issues/134

Add `APACHE_LOGGING_PATH` path env variable for apache customlogs
This allows us to disable the logs by sending it to `/dev/null` by passing env `APACHE_LOGGING_PATH=/dev/null`