### PR TITLE
Remove node npm yarn from current PHP images

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -11,14 +11,9 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip nodejs yarn wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -8,14 +8,9 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip nodejs yarn wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -11,18 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -8,18 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -11,18 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -8,18 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -11,18 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -8,18 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip nodejs yarn wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -11,18 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -8,18 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
-  curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update -y && \
+RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip nodejs npm yarn wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
Issue #137 

We have adjusted CI of C10 core, oC10 apps, oCIS and web so that it uses `owncloudci/nodejs:14` for all things that need nodejs (and npm and yarn are the same "bundle" of JS things).

This PR  removes `node` `npm` and `yarn` from the "current" PHP docker images - PHP 7.3, 7.4, 8.0 and "latest". Those are the images that actually get used these days. (We dropped PHP 7.2 in oC10 core and apps 2 weeks ago)

I didn't touch the older PHP images 5.6 7.0 7.1 7.2 - IMO they can stay like they are for "a long time" (= until we decide to delete them, if we ever do that)

After merging this, we will soon find out what other repos use these docker images and also depend on have these JS tools embedded in a PHP docker image.

Comments welcome...