### PR TITLE
Install python v2 in PHP images

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -13,7 +13,7 @@ ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 python php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -10,7 +10,7 @@ ENV APACHE_LOGGING_PATH=/dev/stdout
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
+  apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 python php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 python php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.3 libxml2-utils git-core unzip wget fontconfig libaio1 python php7.3 php7.3-dev php7.3-xml php7.3-mbstring php7.3-curl php7.3-gd php7.3-zip php7.3-intl php7.3-sqlite3 php7.3-mysql php7.3-pgsql php7.3-soap php7.3-phpdbg php7.3-ldap php7.3-gmp php7.3-imap php7.3-redis php7.3-memcached php7.3-imagick php7.3-smbclient php7.3-apcu php7.3-apcu-bc php7.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 python php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 python php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
PR #138 removed node, npm and yarn. Somehow we lost python v2 by doing that - I guess that it happened to be a dependency of one or more of those removed tools.

But we need python v2 for the caldav/carddav test suites. There is not yet a version of those test suites that passes with python v3.
See https://github.com/apple/ccs-caldavtester/issues/39 and https://github.com/apple/ccs-caldavtester/pull/40 for recent progress on that in the upstream repo.

This PR explicitly installs python v2 in the PHP images, so that we can get oC10 core CI green again.