### PR TITLE
Disable open_basedir on Ubuntu 20.04

### DIFF
--- a/v7.4-ubuntu20.04/overlay/etc/php/7.4/apache2/conf.d/20-open_basedir-custom.ini
+++ b/v7.4-ubuntu20.04/overlay/etc/php/7.4/apache2/conf.d/20-open_basedir-custom.ini
@@ -1,0 +1,1 @@
+open_basedir=""

--- a/v7.4-ubuntu20.04/overlay/etc/php/7.4/cli/conf.d/20-open_basedir-custom.ini
+++ b/v7.4-ubuntu20.04/overlay/etc/php/7.4/cli/conf.d/20-open_basedir-custom.ini
@@ -1,0 +1,1 @@
+open_basedir=""

--- a/v7.4-ubuntu20.04/overlay/etc/php/7.4/fpm/conf.d/20-open_basedir-custom.ini
+++ b/v7.4-ubuntu20.04/overlay/etc/php/7.4/fpm/conf.d/20-open_basedir-custom.ini
@@ -1,0 +1,1 @@
+open_basedir=""

--- a/v7.4-ubuntu20.04/overlay/etc/php/7.4/mods-available/open_basedir-custom.ini
+++ b/v7.4-ubuntu20.04/overlay/etc/php/7.4/mods-available/open_basedir-custom.ini
@@ -1,0 +1,1 @@
+open_basedir=""

--- a/v7.4-ubuntu20.04/overlay/etc/php/7.4/phpdbg/conf.d/20-open_basedir-custom.ini
+++ b/v7.4-ubuntu20.04/overlay/etc/php/7.4/phpdbg/conf.d/20-open_basedir-custom.ini
@@ -1,0 +1,1 @@
+open_basedir=""


### PR DESCRIPTION
https://github.com/owncloud/core/blob/master/lib/private/LargeFileHelper.php#L115 `getFileSizeViaCurl()` requires that `open_basedir` is not set (is the empty string).

In Ubuntu 20.04 with PHP 7.4 `php.ini` sets it by default. That causes some unit tests to fail in https://github.com/owncloud/core/pull/39460:

```
1) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #0 ('/drone/src/tests/data/lorem.txt', 446)
Failed asserting that null is identical to 446.

/drone/src/tests/lib/LargeFileHelperGetFileSizeTest.php:53

2) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #1 ('/drone/src/tests/data/strängé...2).txt', 446)
Failed asserting that null is identical to 446.

/drone/src/tests/lib/LargeFileHelperGetFileSizeTest.php:53
```

This PR sets `open_basedir` to the empty string, like it was in Ubuntu 18.04.