### PR TITLE
Bump to oci8-3.0.1 for PHP 8

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -192,7 +192,7 @@ def notification(config):
 def prepublish(config):
   return [{
     'name': 'prepublish',
-    'image': 'plugins/docker',
+    'image': 'plugins/docker:20.10.9',
     'settings': {
       'username': {
         'from_secret': 'internal_username',
@@ -257,7 +257,7 @@ def tests(config):
 def publish(config):
   return [{
     'name': 'publish',
-    'image': 'plugins/docker',
+    'image': 'plugins/docker:20.10.9',
     'settings': {
       'username': {
         'from_secret': 'public_username',

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -38,7 +38,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.0.0
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.0.1
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -38,7 +38,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.0.1
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.2.1
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud


### PR DESCRIPTION
https://pecl.php.net/package/oci8
"Use 'pecl install oci8-3.0.1' to install for PHP 8.0."
