### PR TITLE
Use the needed PHP version for PHP 5.6 and 8.0 pipelines

### DIFF
--- a/v5.6/Dockerfile.amd64
+++ b/v5.6/Dockerfile.amd64
@@ -28,6 +28,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs
 
+RUN update-alternatives --set php /usr/bin/php5.6
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 RUN curl -sSo oracle-instantclient12.2-basic_12.2.0.1.0-2_amd64.deb https://minio.owncloud.com/packages/oracle/oracle-instantclient12.2-basic_12.2.0.1.0-2_amd64.deb && \

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -23,6 +23,8 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs
 
+RUN update-alternatives --set php /usr/bin/php8.0
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 RUN curl -sSo oracle-instantclient12.2-basic_12.2.0.1.0-2_amd64.deb https://minio.owncloud.com/packages/oracle/oracle-instantclient12.2-basic_12.2.0.1.0-2_amd64.deb && \


### PR DESCRIPTION
    Switch to the needed PHP version for CI of PHP 5.6 and 8.0
    
    For the PHP 5.6 pipeline, plugins/docker has PHP 7.0 running.
    Switch to PHP 5.6 so that later Oracle oci8 etc steps pass.
    
    For the PHP 8.0 pipeline, plugins/docker has PHP 8.1 running.
    Switch to PHP 8.0 so that later Oracle oci8 etc steps pass.

Fixes #143 