### PR TITLE
Bump oci8 versions

### DIFF
--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -42,7 +42,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.1.8
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.2.0
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -42,7 +42,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.1.8
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.2.0
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -42,7 +42,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.1.8
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-2.2.0
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -40,7 +40,7 @@ RUN curl -sSo oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb https://mini
   rm oracle-instantclient12.2-devel_12.2.0.1.0-2_amd64.deb
 
 RUN ln -s /usr/include/oracle/12.2/client64 /usr/lib/oracle/12.2/client64/include && \
-  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.0.0
+  echo "instantclient,/usr/lib/oracle/12.2/client64/lib" | pecl install oci8-3.0.1
 
 COPY ./overlay ./overlay-amd64 /
 WORKDIR /var/www/owncloud


### PR DESCRIPTION
to the current versions listed at https://pecl.php.net/package/oci8