### PR TITLE
Add the retry script to owncloudci/php images

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 python php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y apache2 libapache2-mod-php libxml2-utils mysql-client postgresql-client sqlite git-core unzip wget fontconfig libaio1 python php php-dev php-xml php-mbstring php-curl php-gd php-zip php-intl php-sqlite3 php-mysql php-pgsql php-soap php-phpdbg php-redis php-memcached php-imagick php-smbclient php-apcu php-ldap php-gmp php-imap php-ast && \

--- a/v5.6/Dockerfile.amd64
+++ b/v5.6/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v5.6/Dockerfile.arm64v8
+++ b/v5.6/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.0/Dockerfile.amd64
+++ b/v7.0/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.0/Dockerfile.arm64v8
+++ b/v7.0/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.1/Dockerfile.amd64
+++ b/v7.1/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.1/Dockerfile.arm64v8
+++ b/v7.1/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.2/Dockerfile.amd64
+++ b/v7.2/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.2/Dockerfile.arm64v8
+++ b/v7.2/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://deb.nodesource.com/node_8.x bionic main" | tee /etc/apt/sources.list.d/node.list && \
   curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/v7.3/Dockerfile.amd64
+++ b/v7.3/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.3/Dockerfile.arm64v8
+++ b/v7.3/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4-ubuntu20.04/Dockerfile.amd64
+++ b/v7.4-ubuntu20.04/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4-ubuntu20.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu20.04/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4-ubuntu22.04/Dockerfile.amd64
+++ b/v7.4-ubuntu22.04/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4-ubuntu22.04/Dockerfile.arm64v8
+++ b/v7.4-ubuntu22.04/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4/Dockerfile.amd64
+++ b/v7.4/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v7.4/Dockerfile.arm64v8
+++ b/v7.4/Dockerfile.arm64v8
@@ -13,6 +13,14 @@ RUN apt-get update -y && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get install -y apache2 libapache2-mod-php7.4 libxml2-utils git-core unzip wget fontconfig libaio1 python php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \

--- a/v8.0/Dockerfile.amd64
+++ b/v8.0/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v8.0/Dockerfile.arm64v8
+++ b/v8.0/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v8.1/Dockerfile.amd64
+++ b/v8.1/Dockerfile.amd64
@@ -11,6 +11,14 @@ ENV ORACLE_HOME=/usr/lib/oracle/12.2/client64
 ENV LD_LIBRARY_PATH=/usr/lib/oracle/12.2/client64/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \

--- a/v8.1/Dockerfile.arm64v8
+++ b/v8.1/Dockerfile.arm64v8
@@ -8,6 +8,14 @@ LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
 VOLUME ["/var/www/owncloud"]
 ENV APACHE_LOGGING_PATH=/dev/stdout
 
+ARG RETRY_VERSION
+
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/releases/download/v${RETRY_VERSION##v}/retry" && \
+  chmod 755 /usr/local/bin/retry
+
 RUN apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php && \


### PR DESCRIPTION
Issue https://github.com/owncloud-ci/retry/issues/7

I added `retry` to all the image tags because we have CI that does upgrade-testing, and that has pipelines that start by installing old oC10 releases on an old PHP version. So those images are still used a little bit. Having `retry` in all the tagged versions will avoid "random problems" when it gets used in CI.