### PR TITLE
chore: bump Ubuntu from 20.04 to 22.04 for the default PHP 7.4 image

### DIFF
--- a/v7.4/Dockerfile.multiarch
+++ b/v7.4/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM docker.io/owncloud/ubuntu:20.04@sha256:06302476d6391ff2b30fd5e7c0cf52a4ca2a67bc4b78fd1e64d89e75bd37ce89
+FROM docker.io/owncloud/ubuntu:22.04@sha256:4ba4c894fbf73bbf16391e53145086d9a0863c868387ef2562f46a534c162601
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \


### PR DESCRIPTION
Ubuntu 20.04 is very old anyway, so use Ubuntu 22.04 as the base image for the "default" PHP 7.4 docker image.