### PR TITLE
chore: install libimage-exiftool-perl for files_classifier

### DIFF
--- a/v7.4-ubuntu22.04/Dockerfile.multiarch
+++ b/v7.4-ubuntu22.04/Dockerfile.multiarch
@@ -37,7 +37,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libkrb5-dev libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libkrb5-dev libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync libimage-exiftool-perl && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v7.4/Dockerfile.multiarch
+++ b/v7.4/Dockerfile.multiarch
@@ -37,7 +37,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php7.4 libkrb5-dev libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php7.4 libkrb5-dev libxml2-utils git-core unzip wget fontconfig libaio1 python2 php7.4 php7.4-dev php7.4-xml php7.4-mbstring php7.4-curl php7.4-gd php7.4-zip php7.4-intl php7.4-sqlite3 php7.4-mysql php7.4-pgsql php7.4-soap php7.4-phpdbg php7.4-ldap php7.4-gmp php7.4-imap php7.4-redis php7.4-memcached php7.4-imagick php7.4-smbclient php7.4-apcu php7.4-apcu-bc php7.4-ast rsync libimage-exiftool-perl && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
https://github.com/owncloud/files_classifier/pull/796 added `exif` tool to allow looking into PDF files for classification.

That needs `libimage-exiftool-perl`.

With the new Freexian PHP 7.4 `owncloudci/php` image, we can't do general `apt install` to it on-the-fly in CI, because that causes it to try to access our Freexian deb mirror, and that requires authentication.

So for CI, it will be easiest to have software like this pre-installed. And this PHP image is only for use in CI, so it's not an issue for production installs that use docker - they are based on `owncloud-docker/php`