### PR TITLE
chore: use docker buildkit secret

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -136,7 +136,7 @@ def prepublish(config):
                     "from_secret": "internal_password",
                 },
                 "tags": config["internal"],
-                "build_args_from_env": ["DEB_MIRROR_URL", "DEB_MIRROR_LOGIN", "DEB_MIRROR_PWD"],
+                "secrets": ["id=mirror-auth\\\\,src=/drone/src/mirror-auth", "id=mirror-url\\\\,src=/drone/src/mirror-url"],
                 "dockerfile": "%s/Dockerfile.multiarch" % (config["version"]["path"]),
                 "repo": "registry.drone.owncloud.com/owncloudci/%s" % config["repo"],
                 "registry": "registry.drone.owncloud.com",
@@ -145,15 +145,6 @@ def prepublish(config):
             },
             "environment": {
                 "BUILDKIT_NO_CLIENT_TOKEN": True,
-                "DEB_MIRROR_URL": {
-                    "from_secret": "DEB_MIRROR_URL",
-                },
-                "DEB_MIRROR_LOGIN": {
-                    "from_secret": "DEB_MIRROR_LOGIN",
-                },
-                "DEB_MIRROR_PWD": {
-                    "from_secret": "DEB_MIRROR_PWD",
-                },
             },
         },
     ]
@@ -230,12 +221,26 @@ def publish(config):
                     "linux/arm64",
                 ],
                 "tags": config["version"]["tags"],
-                "build_args_from_env": ["DEB_MIRROR_URL", "DEB_MIRROR_LOGIN", "DEB_MIRROR_PWD"],
+                "secrets": ["id=mirror-auth\\\\,src=/drone/src/mirror-auth", "id=mirror-url\\\\,src=/drone/src/mirror-url"],
                 "dockerfile": "%s/Dockerfile.multiarch" % (config["version"]["path"]),
                 "repo": "owncloudci/%s" % config["repo"],
                 "context": config["version"]["path"],
                 "pull_image": False,
             },
+            "when": {
+                "ref": [
+                    "refs/heads/master",
+                ],
+            },
+        },
+    ]
+
+def setup(config):
+    return [
+        {
+            "name": "setup",
+            "image": "docker.io/owncloudci/alpine",
+            "failure": "ignore",
             "environment": {
                 "DEB_MIRROR_URL": {
                     "from_secret": "DEB_MIRROR_URL",
@@ -247,11 +252,10 @@ def publish(config):
                     "from_secret": "DEB_MIRROR_PWD",
                 },
             },
-            "when": {
-                "ref": [
-                    "refs/heads/master",
-                ],
-            },
+            "commands": [
+                'echo "machine $DEB_MIRROR_URL login $DEB_MIRROR_LOGIN password $DEB_MIRROR_PWD" > mirror-auth',
+                'echo "$DEB_MIRROR_URL" > mirror-url',
+            ],
         },
     ]
 
@@ -270,6 +274,8 @@ def cleanup(config):
                 },
             },
             "commands": [
+                "rm -f mirror-auth",
+                "rm -f mirror-url",
                 "regctl registry login registry.drone.owncloud.com --user $DOCKER_USER --pass $DOCKER_PASSWORD",
                 "regctl tag rm registry.drone.owncloud.com/owncloudci/%s:%s" % (config["repo"], config["internal"]),
             ],
@@ -367,4 +373,4 @@ def tests(config):
     }]
 
 def steps(config):
-    return prepublish(config) + sleep(config) + trivy(config) + assert(config) + server(config) + wait(config) + tests(config) + publish(config) + cleanup(config)
+    return setup(config) + prepublish(config) + sleep(config) + trivy(config) + assert(config) + server(config) + wait(config) + tests(config) + publish(config) + cleanup(config)

--- a/v7.4-ubuntu22.04/Dockerfile.multiarch
+++ b/v7.4-ubuntu22.04/Dockerfile.multiarch
@@ -15,9 +15,6 @@ ENV APACHE_LOGGING_PATH=/dev/stdout
 
 ARG RETRY_VERSION
 ARG TARGETPLATFORM
-ARG DEB_MIRROR_URL
-ARG DEB_MIRROR_LOGIN
-ARG DEB_MIRROR_PWD
 
 # renovate: datasource=github-releases depName=owncloud-ci/retry
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
@@ -28,11 +25,12 @@ RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/rel
 # Get the key that the Freexian deb mirror uses for signing
 RUN wget http://php.freexian.com/public/archive-key.gpg -O /etc/apt/trusted.gpg.d/freexian-archive-php.gpg
 # Get the authentication details for the deb mirror that has been set up to serve the Freexian PHP packages
-RUN echo "machine $DEB_MIRROR_URL login $DEB_MIRROR_LOGIN password $DEB_MIRROR_PWD" > /etc/apt/auth.conf.d/freexian.conf
+RUN --mount=type=secret,id=mirror-auth,required cp /run/secrets/mirror-auth /etc/apt/auth.conf.d/freexian.conf
 
-RUN apt-get update -y && \
+
+RUN --mount=type=secret,id=mirror-url,required apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
-  apt-add-repository "https://$DEB_MIRROR_URL/php.freexian.com/ bookworm main" && \
+  apt-add-repository "https://$(cat /run/secrets/mirror-url)/php.freexian.com/ bookworm main" && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \

--- a/v7.4/Dockerfile.multiarch
+++ b/v7.4/Dockerfile.multiarch
@@ -15,9 +15,6 @@ ENV APACHE_LOGGING_PATH=/dev/stdout
 
 ARG RETRY_VERSION
 ARG TARGETPLATFORM
-ARG DEB_MIRROR_URL
-ARG DEB_MIRROR_LOGIN
-ARG DEB_MIRROR_PWD
 
 # renovate: datasource=github-releases depName=owncloud-ci/retry
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
@@ -28,11 +25,12 @@ RUN curl -SsfL -o /usr/local/bin/retry "https://github.com/owncloud-ci/retry/rel
 # Get the key that the Freexian deb mirror uses for signing
 RUN wget http://php.freexian.com/public/archive-key.gpg -O /etc/apt/trusted.gpg.d/freexian-archive-php.gpg
 # Get the authentication details for the deb mirror that has been set up to serve the Freexian PHP packages
-RUN echo "machine $DEB_MIRROR_URL login $DEB_MIRROR_LOGIN password $DEB_MIRROR_PWD" > /etc/apt/auth.conf.d/freexian.conf
+RUN --mount=type=secret,id=mirror-auth,required cp /run/secrets/mirror-auth /etc/apt/auth.conf.d/freexian.conf
 
-RUN apt-get update -y && \
+
+RUN --mount=type=secret,id=mirror-url,required apt-get update -y && \
   apt-get install -y software-properties-common language-pack-en-base && \
-  apt-add-repository "https://$DEB_MIRROR_URL/php.freexian.com/ bookworm main" && \
+  apt-add-repository "https://$(cat /run/secrets/mirror-url)/php.freexian.com/ bookworm main" && \
   LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/apache2
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Use the "secrets" functionality of docker buildkit to pass in the authentication for the Freexian deb package server.
The drone secrets are put into temporary files that are passed into `owncloudci/drone-docker-buildx` and are used there to access the Freexian deb package server. Those files are discarded at the end of the CI pipeline, they do not end up in the published image details.