### PR TITLE
chore: bump the PHP8 images to use Ubuntu 22.04

### DIFF
--- a/v8.0/Dockerfile.multiarch
+++ b/v8.0/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM docker.io/owncloud/ubuntu:20.04@sha256:9cdc86249b1667ecec25b6f6db6a3d8e82a1ec7c7d09ca9916f3a3073ceefb83
+FROM docker.io/owncloud/ubuntu:22.04@sha256:46a939e9756ce2990076b305d3a3717e13b0a8d8c5edd116c420aef6793af30f
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \
@@ -29,7 +29,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.0 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php8.0 php8.0-dev php8.0-xml php8.0-mbstring php8.0-curl php8.0-gd php8.0-zip php8.0-intl php8.0-sqlite3 php8.0-mysql php8.0-pgsql php8.0-soap php8.0-phpdbg php8.0-ldap php8.0-gmp php8.0-imap php8.0-redis php8.0-memcached php8.0-imagick php8.0-smbclient php8.0-apcu php8.0-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.1/Dockerfile.multiarch
+++ b/v8.1/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM docker.io/owncloud/ubuntu:20.04@sha256:9cdc86249b1667ecec25b6f6db6a3d8e82a1ec7c7d09ca9916f3a3073ceefb83
+FROM docker.io/owncloud/ubuntu:22.04@sha256:46a939e9756ce2990076b305d3a3717e13b0a8d8c5edd116c420aef6793af30f
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \
@@ -29,7 +29,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.1 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.1 php8.1-dev php8.1-xml php8.1-mbstring php8.1-curl php8.1-gd php8.1-zip php8.1-intl php8.1-sqlite3 php8.1-mysql php8.1-pgsql php8.1-soap php8.1-phpdbg php8.1-ldap php8.1-gmp php8.1-imap php8.1-redis php8.1-memcached php8.1-imagick php8.1-smbclient php8.1-apcu php8.1-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.1 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php8.1 php8.1-dev php8.1-xml php8.1-mbstring php8.1-curl php8.1-gd php8.1-zip php8.1-intl php8.1-sqlite3 php8.1-mysql php8.1-pgsql php8.1-soap php8.1-phpdbg php8.1-ldap php8.1-gmp php8.1-imap php8.1-redis php8.1-memcached php8.1-imagick php8.1-smbclient php8.1-apcu php8.1-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.2/Dockerfile.multiarch
+++ b/v8.2/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM docker.io/owncloud/ubuntu:20.04@sha256:9cdc86249b1667ecec25b6f6db6a3d8e82a1ec7c7d09ca9916f3a3073ceefb83
+FROM docker.io/owncloud/ubuntu:22.04@sha256:46a939e9756ce2990076b305d3a3717e13b0a8d8c5edd116c420aef6793af30f
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \
@@ -29,7 +29,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.2 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.2 php8.2-dev php8.2-xml php8.2-mbstring php8.2-curl php8.2-gd php8.2-zip php8.2-intl php8.2-sqlite3 php8.2-mysql php8.2-pgsql php8.2-soap php8.2-phpdbg php8.2-ldap php8.2-gmp php8.2-imap php8.2-redis php8.2-memcached php8.2-imagick php8.2-smbclient php8.2-apcu php8.2-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.2 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php8.2 php8.2-dev php8.2-xml php8.2-mbstring php8.2-curl php8.2-gd php8.2-zip php8.2-intl php8.2-sqlite3 php8.2-mysql php8.2-pgsql php8.2-soap php8.2-phpdbg php8.2-ldap php8.2-gmp php8.2-imap php8.2-redis php8.2-memcached php8.2-imagick php8.2-smbclient php8.2-apcu php8.2-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs

--- a/v8.3/Dockerfile.multiarch
+++ b/v8.3/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM docker.io/owncloud/ubuntu:20.04@sha256:9cdc86249b1667ecec25b6f6db6a3d8e82a1ec7c7d09ca9916f3a3073ceefb83
+FROM docker.io/owncloud/ubuntu:22.04@sha256:46a939e9756ce2990076b305d3a3717e13b0a8d8c5edd116c420aef6793af30f
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \
@@ -29,7 +29,7 @@ RUN apt-get update -y && \
 
 RUN apt-get update -y && \
   apt-get upgrade -y && \
-  apt-get install -y apache2 libapache2-mod-php8.3 libxml2-utils git-core unzip wget fontconfig libaio1 python php8.3 php8.3-dev php8.3-xml php8.3-mbstring php8.3-curl php8.3-gd php8.3-zip php8.3-intl php8.3-sqlite3 php8.3-mysql php8.3-pgsql php8.3-soap php8.3-phpdbg php8.3-ldap php8.3-gmp php8.3-imap php8.3-redis php8.3-memcached php8.3-imagick php8.3-smbclient php8.3-apcu php8.3-ast rsync && \
+  apt-get install -y apache2 libapache2-mod-php8.3 libxml2-utils git-core unzip wget fontconfig libaio1 python2 php8.3 php8.3-dev php8.3-xml php8.3-mbstring php8.3-curl php8.3-gd php8.3-zip php8.3-intl php8.3-sqlite3 php8.3-mysql php8.3-pgsql php8.3-soap php8.3-phpdbg php8.3-ldap php8.3-gmp php8.3-imap php8.3-redis php8.3-memcached php8.3-imagick php8.3-smbclient php8.3-apcu php8.3-ast rsync && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs


### PR DESCRIPTION
These were only being used to test things with PHP8.x.
We might as well move them forward to be based on Ubuntu 22.04.