### PR TITLE
chore(docker): update cURL to v8.12.0 to fix timeout on MKCOL with `Transfer-Encoding: chunked` header

### DIFF
--- a/v8.4/Dockerfile.multiarch
+++ b/v8.4/Dockerfile.multiarch
@@ -34,6 +34,13 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/apache2/sites-available/default-ssl.conf && \
   a2enmod rewrite headers env dir mime ssl expires dav dav_fs
 
+RUN apt-get update -y && apt-get upgrade -y && apt-get remove -y curl && apt-get purge -y curl && \
+  apt-get install -y libldap-dev libpsl-dev libssh-dev && \
+  cd /usr/local/src && rm -rf curl* && \
+  wget https://curl.se/download/curl-8.12.0.zip && unzip curl-8.12.0.zip && cd curl-8.*/ && \
+  ./configure --with-ssl --with-zlib --with-gssapi --enable-ldap --enable-ldaps --with-libssh --with-nghttp2 && \
+  make && make install && ldconfig && cd / && rm -rf /usr/local/src/curl*
+
 RUN update-alternatives --set php /usr/bin/php8.4
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer


### PR DESCRIPTION
## Description  
Update cURL to **v8.12.0** to fix timeout on MKCOL with `Transfer-Encoding: chunked` header

---

### Problem

When running WebDAV tests involving `MKCOL` requests with the header `Transfer-Encoding: chunked`, the request failed with a timeout error using cURL version **7.81.0**.

Error message:
```bash
cURL error 28: Operation timed out after 60003 milliseconds with 0 bytes received
```
This occurred while trying to create a folder using the following request:
```bash
curl -kv -XMKCOL 'https://localhost:9200/remote.php/dav/spaces/<id>/<folder>' \
  -u admin:admin \
  -H 'Transfer-Encoding: chunked'
```

---

### Related Issue

https://github.com/owncloud/ocis/issues/10809

---


### Fix

Updated the Dockerfile to manually build and install cURL **v8.12.0** from source. This version correctly supports `Transfer-Encoding: chunked` in `MKCOL` requests and resolves the timeout issue.

Changes made:
- Removed the old cURL version
- Installed dependencies required to compile cURL
- Downloaded and built cURL v8.12.0
- Cleaned up build artifacts post-installation

---


### Testing

The test failed due to the outdated cURL version not handling the request properly. After upgrading to cURL **v8.12.0**, the `MKCOL` request with `Transfer-Encoding: chunked` was successful, and the test passed as expected. 

